### PR TITLE
Use meta data files from NVD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,16 @@
-.gradle
-.gradletasknamecache
-build/
 /target/
+# Intellij project files
+*.iml
+*.ipr
+*.iws
+.idea/
+# Eclipse project files
+.classpath
+.project
+.settings
+maven-eclipse.xml
+.externalToolBuilders
+.pmd
+# Netbeans configuration
+nb-configuration.xml
+**/nbproject/

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>us.springett</groupId>
     <artifactId>nist-data-mirror</artifactId>
     <packaging>jar</packaging>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
 
     <name>NIST Data Mirror</name>
     <description>

--- a/src/docker/scripts/mirror.sh
+++ b/src/docker/scripts/mirror.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-files=`java -jar /usr/local/bin/nist-data-mirror.jar /tmp/nvd | grep -Eo 'Uncompressing.*' | grep -Eo '[^ ]*\.gz'`
+files=`java -jar /usr/local/bin/nist-data-mirror.jar /tmp/nvd | grep -Eo '(Download succeeded|Uncompressed).*' | grep -Eo '[^ ]*\.(gz|meta|json|xml)'`
 
 timestamp=$(date +%s)
 

--- a/src/main/java/us/springett/nistdatamirror/MetaProperties.java
+++ b/src/main/java/us/springett/nistdatamirror/MetaProperties.java
@@ -1,0 +1,148 @@
+/*
+ * This file is part of nist-data-mirror.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package us.springett.nistdatamirror;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Properties;
+
+/**
+ * Meta properties object to hold information about the NVD CVE data.
+ *
+ * @author Jeremy Long
+ */
+public class MetaProperties {
+
+    /**
+     * The SHA256 of the NVD file.
+     */
+    private String sha256;
+    /**
+     * The last modified date of the NVD file in epoch time.
+     */
+    private long lastModifiedDate;
+    /**
+     * The size of the NVD file.
+     */
+    private long size = 0;
+    /**
+     * The size of the zipped NVD file.
+     */
+    private long zipSize = 0;
+    /**
+     * The size of the gzipped NVD file.
+     */
+    private long gzSize = 0;
+
+    /**
+     * Get the value of gzSize.
+     *
+     * @return the value of gzSize
+     */
+    public long getGzSize() {
+        return gzSize;
+    }
+
+    /**
+     * Get the value of zipSize.
+     *
+     * @return the value of zipSize
+     */
+    public long getZipSize() {
+        return zipSize;
+    }
+
+    /**
+     * Get the value of size.
+     *
+     * @return the value of size
+     */
+    public long getSize() {
+        return size;
+    }
+
+    /**
+     * Get the value of lastModifiedDate in epoch time.
+     *
+     * @return the value of lastModifiedDate
+     */
+    public long getLastModifiedDate() {
+        return lastModifiedDate;
+    }
+
+    /**
+     * Get the value of SHA256
+     *
+     * @return the value of SHA256
+     */
+    public String getSha256() {
+        return sha256;
+    }
+
+    /**
+     * Constructs a new MetaProperties object to hold information about the NVD
+     * data.
+     *
+     * @param file the path to the meta properties file
+     * @throws MirrorException thrown if the meta file contents cannot be parsed
+     */
+    public MetaProperties(File file) throws MirrorException {
+        Properties properties = new Properties();
+        try (FileReader in = new FileReader(file);
+                BufferedReader br = new BufferedReader(in)) {
+            properties.load(br);
+        } catch (IOException ex) {
+            throw new MirrorException("Unable to parse meta file data", ex);
+        }
+        this.sha256 = properties.getProperty("sha256");
+        try {
+            String date = properties.getProperty("lastModifiedDate");
+            if (date == null) {
+                throw new RuntimeException("lastModifiedDate not found in meta file");
+            }
+            this.lastModifiedDate = ZonedDateTime.parse(date, DateTimeFormatter.ISO_OFFSET_DATE_TIME).toEpochSecond();
+        } catch (DateTimeParseException ex) {
+            throw new MirrorException("Meta file lastModifiedDate cannot be parsed: "
+                    + properties.getProperty("lastModifiedDate"), ex);
+        }
+        try {
+            this.zipSize = Long.parseLong(properties.getProperty("zipSize"));
+        } catch (NumberFormatException ex) {
+            throw new MirrorException("Meta file zip size cannot be parsed: "
+                    + properties.getProperty("zipSize"), ex);
+        }
+        try {
+            this.gzSize = Long.parseLong(properties.getProperty("gzSize"));
+        } catch (NumberFormatException ex) {
+            throw new MirrorException("Meta file gz size cannot be parsed: "
+                    + properties.getProperty("gzSize"), ex);
+        }
+        try {
+            this.size = Long.parseLong(properties.getProperty("size"));
+        } catch (NumberFormatException ex) {
+            throw new MirrorException("Meta file size cannot be parsed: "
+                    + properties.getProperty("size"), ex);
+        }
+    }
+}

--- a/src/main/java/us/springett/nistdatamirror/MirrorException.java
+++ b/src/main/java/us/springett/nistdatamirror/MirrorException.java
@@ -1,0 +1,66 @@
+/*
+ * This file is part of nist-data-mirror.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package us.springett.nistdatamirror;
+
+import java.io.IOException;
+
+/**
+ * An exception used when the there is an error mirroring the NVD CVE.
+ *
+ * @author Jeremy Long
+ */
+public class MirrorException extends IOException {
+
+    /**
+     * The serial version UID for serialization.
+     */
+    private static final long serialVersionUID = 2048042874653986535L;
+
+    /**
+     * Creates a new MirrorException.
+     */
+    public MirrorException() {
+        super();
+    }
+
+    /**
+     * Creates a new MirrorException.
+     *
+     * @param msg a message for the exception.
+     */
+    public MirrorException(String msg) {
+        super(msg);
+    }
+
+    /**
+     * Creates a new MirrorException.
+     *
+     * @param ex the cause of the exception.
+     */
+    public MirrorException(Throwable ex) {
+        super(ex);
+    }
+
+    /**
+     * Creates a new MirrorException.
+     *
+     * @param msg a message for the exception.
+     * @param ex the cause of the exception.
+     */
+    public MirrorException(String msg, Throwable ex) {
+        super(msg, ex);
+    }
+}

--- a/src/main/java/us/springett/nistdatamirror/NistDataMirror.java
+++ b/src/main/java/us/springett/nistdatamirror/NistDataMirror.java
@@ -104,6 +104,12 @@ public class NistDataMirror {
             MetaProperties after = readLocalMetaForURL(CVE_MODIFIED_META);
             if (before == null || after.getLastModifiedDate() > before.getLastModifiedDate()) {
                 if (xml) {
+                    System.out.println("---------------------------------------------------------");
+                    System.out.println("---------------------------------------------------------");
+                    System.out.println("WARNING: NVD CVE XML files are being mirrored - these files will be discontinued in the future; "
+                            + "see https://nvd.nist.gov/General/News/XML-Vulnerability-Feed-Retirement");
+                    System.out.println("---------------------------------------------------------");
+                    System.out.println("---------------------------------------------------------");
                     doDownload(CVE_XML_12_MODIFIED_URL);
                     doDownload(CVE_XML_20_MODIFIED_URL);
                 }

--- a/src/main/java/us/springett/nistdatamirror/NistDataMirror.java
+++ b/src/main/java/us/springett/nistdatamirror/NistDataMirror.java
@@ -17,10 +17,13 @@ package us.springett.nistdatamirror;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
+import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.io.FileReader;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -99,9 +102,9 @@ public class NistDataMirror {
             doDownload(CVE_JSON_10_MODIFIED_URL);
         }
         for (int i = START_YEAR; i <= END_YEAR; i++) {
-            String cveBaseUrl = CVE_BASE_META.replace("%d", String.valueOf(i));
-            doDownload(cveBaseUrl);
-            
+            String cveBaseMetaUrl = CVE_BASE_META.replace("%d", String.valueOf(i));
+            doDownload(cveBaseMetaUrl);
+
             if (xml) {
                 String cve12BaseUrl = CVE_XML_12_BASE_URL.replace("%d", String.valueOf(i));
                 String cve20BaseUrl = CVE_XML_20_BASE_URL.replace("%d", String.valueOf(i));
@@ -129,13 +132,23 @@ public class NistDataMirror {
         return 0;
     }
 
-    private void doDownload(String cveUrl) {
+    private MetaProperties readLocalMetaForURL(URL url) throws MirrorException {
+        MetaProperties meta = null;
+        String filename = url.getFile();
+        filename = filename.substring(filename.lastIndexOf('/') + 1);
+        File file = new File(outputDir, filename).getAbsoluteFile();
+        if (file.isFile()) {
+            meta = new MetaProperties(file);
+        }
+        return meta;
+    }
+
+    private void doDownload(URL url) {
         BufferedInputStream bis = null;
         BufferedOutputStream bos = null;
         File file = null;
         boolean success = false;
         try {
-            URL url = new URL(cveUrl);
             String filename = url.getFile();
             filename = filename.substring(filename.lastIndexOf('/') + 1);
             file = new File(outputDir, filename).getAbsoluteFile();


### PR DESCRIPTION
This PR adds the use of the meta data files instead of HEAD requests to determine if the data should be downloaded.

- bumped minor version of the project
- Warning banner is displayed if mirroring the XML files
- Only the META files for the JSON data feeds are being used to determine if a file should be updated (including the XML files)