### PR TITLE
Extend proxy support for build & runtime and support non-root users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ FROM httpd:alpine
 ARG BUILD_DATE
 ARG BUILD_VERSION
 
+ARG http_proxy
+ARG https_proxy
+ARG no_proxy
+
 # Labels.
 LABEL maintainer="jeremy.long@gmail.com"
 LABEL name="sspringett/nvdmirror"
@@ -24,9 +28,13 @@ RUN apk update                                                              && \
     mkdir -p /var/log/cron                                                  && \
     mkdir -p /var/spool/cron/crontabs                                       && \
     mkdir /tmp/nvd                                                          && \
-    adduser -D ${user}                                                      && \
     touch /var/log/cron.log                                                 && \
-    rm -rf /var/lib/apt/lists/* /tmp/*
+    chgrp -R 0 /var                                                         && \
+    chmod -R g=u /var                                                       && \
+    chgrp -R 0 /usr/                                                        && \
+    chmod -R g=u /usr                                                       && \
+    chgrp -R 0 /tmp                                                         && \
+    chmod -R g=u /tmp                                                       
 
 RUN echo "Include conf/mirror.conf"                                         
 COPY /src/docker/scripts/* /
@@ -34,9 +42,8 @@ COPY /src/docker/crontab/* /var/spool/cron/crontabs/mirror
 COPY /src/docker/conf/mirror.conf /usr/local/apache2/conf
 COPY /target/nist-data-mirror.jar /usr/local/bin/
 
-EXPOSE 80/tcp
-
-#USER ${user}
+EXPOSE 8080/tcp
 
 ENTRYPOINT ["/entry.sh"]
 CMD ["/cmd.sh"]
+USER 1001

--- a/README.md
+++ b/README.md
@@ -62,12 +62,19 @@ $ docker build --rm -t sspringett/nvdmirror .
 $ mkdir target/docs
 $ docker run -dit \
   --name mirror \
-  -p 80:80 \
+  -p 80:8080 \
   --mount type=bind,source="$(pwd)"/target/docs/,target=/usr/local/apache2/htdocs \
   sspringett/nvdmirror
 ```
 
 The httpd server will take a minute to spin up as it is mirroring the initial NVD files.
+
+To use a proxy during build time provide the `http_proxy`, `https_proxy` and `no_proxy` 
+environment variables as build arguments (e.g. `--build-arg http_proxy="${http_proxy}"`.
+For the runtime you can pass the `http.proxyHost` and `http.proxyPort` values as environment variables (`proxy_host`, `proxy_port`).
+
+The image is designed to be runned as a random non-root user and can be deployed on
+container orchestration platforms such as Kubernetes and OpenShift.
 
 Related Projects
 ----------------

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,3 +1,7 @@
-#!/bin/sh
-
-docker build --no-cache=true --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') -t sspringett/nvdmirror .
+#!/usr/bin/env sh
+docker build --no-cache=true \
+             --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
+             --build-arg http_proxy="${http_proxy}" \
+             --build-arg https_proxy="${https_proxy}" \
+             --build-arg no_proxy="${no_proxy}" \
+             -t sspringett/nvdmirror .

--- a/src/docker/scripts/entry.sh
+++ b/src/docker/scripts/entry.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
 
+# Listen on port 8080 for non-privileged users
+sed -i 's/Listen 80/Listen 8080/g' /usr/local/apache2/conf/httpd.conf 
+
 exec "$@"

--- a/src/docker/scripts/mirror.sh
+++ b/src/docker/scripts/mirror.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-files=`java -jar /usr/local/bin/nist-data-mirror.jar /tmp/nvd | grep -Eo '(Download succeeded|Uncompressed).*' | grep -Eo '[^ ]*\.(gz|meta|json|xml)'`
+files=`java -jar -Dhttp.proxyHost="${proxy_host}" -Dhttp.proxyPort="${proxy_port}" /usr/local/bin/nist-data-mirror.jar /tmp/nvd | grep -Eo '(Download succeeded|Uncompressed).*' | grep -Eo '[^ ]*\.(gz|meta|json|xml)'`
 
 timestamp=$(date +%s)
 


### PR DESCRIPTION
Thanks for providing an in Docker runnable nist-data-mirror. I ran into two issues (proxy configuration & running as root) when using it and would like to upstream my changes:
- Enable proxy support during build time when running behind corporate proxies using build arguments.
- Extend proxy support during the runtime to be able to run the image without modifications using environment variables.
- Run as non-root user and support random uids to be able to deploy on
container orchestration platforms such as Kubernetes and OpenShift.