### PR TITLE
Respect Docker memory limits

### DIFF
--- a/src/docker/scripts/mirror.sh
+++ b/src/docker/scripts/mirror.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-files=`java -jar -Dhttp.proxyHost="${proxy_host}" -Dhttp.proxyPort="${proxy_port}" /usr/local/bin/nist-data-mirror.jar /tmp/nvd | grep -Eo '(Download succeeded|Uncompressed).*' | grep -Eo '[^ ]*\.(gz|meta|json|xml)'`
+files=`java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -jar -Dhttp.proxyHost="${proxy_host}" -Dhttp.proxyPort="${proxy_port}" /usr/local/bin/nist-data-mirror.jar /tmp/nvd | grep -Eo '(Download succeeded|Uncompressed).*' | grep -Eo '[^ ]*\.(gz|meta|json|xml)'`
 
 timestamp=$(date +%s)
 


### PR DESCRIPTION
When using the provided Docker image, the JVM isn't aware of the provided CGroup limits set by Docker. This change tells Java to respect the given limits.

See: https://blogs.oracle.com/java-platform-group/java-se-support-for-docker-cpu-and-memory-limits