### PR TITLE
Remove leftovers of: Removing support for XML feed (69b6ade)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ mvn clean package
 ```sh
 java -jar nist-data-mirror.jar <mirror-directory>
 ```
-Omitting filetype argument will result in both filetypes being downloaded.
 
 To use a proxy provide http.proxyHost / http.proxyPort system properties.
 

--- a/src/main/java/us/springett/nistdatamirror/NistDataMirror.java
+++ b/src/main/java/us/springett/nistdatamirror/NistDataMirror.java
@@ -79,7 +79,7 @@ public class NistDataMirror {
 
     public static void main(String[] args) {
         // Ensure at least one argument was specified
-        if (args.length == 0 || args.length > 2) {
+        if (args.length != 1) {
             System.out.println("Usage: java NistDataMirror outputDir");
             return;
         }


### PR DESCRIPTION
After reading the README I was looking for filetype argument in the code. After some looking around I found the commit which removed this option. So I removed the reference from the README and update the argument check in main().