### PR TITLE
Issue #62 - Allow http proxy values to be supplied through values.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,21 @@
 [![Build Status](https://github.com/stevespringett/nist-data-mirror/workflows/Maven%20CI/badge.svg)](https://github.com/stevespringett/nist-data-mirror/actions?workflow=Maven+CI)
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/21c46e93bdbe4e6f99085da9ece477e3)](https://www.codacy.com/app/stevespringett/nist-data-mirror?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=stevespringett/nist-data-mirror&amp;utm_campaign=Badge_Grade)
-[![License](https://img.shields.io/badge/license-Apache%202.0-brightgreen.svg)][Apache 2.0]
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/21c46e93bdbe4e6f99085da9ece477e3)](https://www.codacy.com/app/stevespringett/nist-data-mirror?utm_source=github.com&utm_medium=referral&utm_content=stevespringett/nist-data-mirror&utm_campaign=Badge_Grade)
+[![License](https://img.shields.io/badge/license-Apache%202.0-brightgreen.svg)][apache 2.0]
 
-NIST Data Mirror
-================
+# NIST Data Mirror
 
 A simple Java command-line utility to mirror the NVD (CPE/CVE JSON) data from NIST.
 
-The intended purpose of nist-data-mirror is to be able to replicate the NIST vulnerabiity data 
+The intended purpose of nist-data-mirror is to be able to replicate the NIST vulnerabiity data
 inside a company firewall so that local (faster) access to NIST data can be achieved.
 
-nist-data-mirror does not rely on any third-party dependencies, only the Java SE core libraries. 
-It can be used in combination with [OWASP Dependency-Check] in order to provide Dependency-Check 
+nist-data-mirror does not rely on any third-party dependencies, only the Java SE core libraries.
+It can be used in combination with [OWASP Dependency-Check] in order to provide Dependency-Check
 a mirrored copy of NIST data.
 
 For best results, use nist-data-mirror with cron or another scheduler to keep the mirrored data fresh.
 
-Usage
-----------------
+## Usage
 
 ### Building
 
@@ -33,10 +31,9 @@ java -jar nist-data-mirror.jar <mirror-directory>
 
 To use a proxy provide http.proxyHost / http.proxyPort system properties.
 
-Downloading
-----------------
+## Downloading
 
-If you do not wish to download sources and compile yourself, [pre-compiled binaries] are available 
+If you do not wish to download sources and compile yourself, [pre-compiled binaries] are available
 for use. NIST Data Mirror is also available on the Maven Central Repository.
 
 ```xml
@@ -47,12 +44,11 @@ for use. NIST Data Mirror is also available on the Maven Central Repository.
 </dependency>
 ```
 
-Docker
-----------------
+## Docker
 
-A Dockerfile is included, and the image is available on Docker Hub as [sspringett/nvdmirror](https://hub.docker.com/r/sspringett/nvdmirror). This was created to 
-assist in debugging other issues. While the image does create an httpd instance 
-that mirrors the NVD CVE data feeds - note that it also creates a backup for all 
+A Dockerfile is included, and the image is available on Docker Hub as [sspringett/nvdmirror](https://hub.docker.com/r/sspringett/nvdmirror). This was created to
+assist in debugging other issues. While the image does create an httpd instance
+that mirrors the NVD CVE data feeds - note that it also creates a backup for all
 changed files and there is currently no automatic cleanup.
 
 ```
@@ -68,20 +64,25 @@ $ docker run -dit \
 
 The httpd server will take a minute to spin up as it is mirroring the initial NVD files.
 
-To use a proxy during build time provide the `http_proxy`, `https_proxy` and `no_proxy` 
+To use a proxy during build time provide the `http_proxy`, `https_proxy` and `no_proxy`
 environment variables as build arguments (e.g. `--build-arg http_proxy="${http_proxy}"`.
-For the runtime you can pass the `http.proxyHost` and `http.proxyPort` values as environment variables (`proxy_host`, `proxy_port`).
+For the runtime you can pass the `http.proxyHost` and `http.proxyPort` values in `_JAVA_OPTIONS`.
+
+For example.
+
+```
+_JAVA_OPTIONS="-Dhttps.proxyHost=yourproxyhost.domain -Dhttps.proxyPort=3128 -Dhttp.proxyHost=yourproxyhost.domain
+      -Dhttp.proxyPort=3128 -Dhttp.nonProxyHosts="localhost|*.domain"
+```
 
 The image is designed to be executed as a random non-root user and can be deployed on
 container orchestration platforms such as Kubernetes and OpenShift.
 
-Related Projects
-----------------
+## Related Projects
 
-* [VulnDB Data Mirror](https://github.com/stevespringett/vulndb-data-mirror)
+- [VulnDB Data Mirror](https://github.com/stevespringett/vulndb-data-mirror)
 
-Copyright & License
--------------------
+## Copyright & License
 
 nist-data-mirror is Copyright (c) Steve Springett. All Rights Reserved.
 
@@ -89,6 +90,6 @@ Dependency-Check is Copyright (c) Jeremy Long. All Rights Reserved.
 
 Permission to modify and redistribute is granted under the terms of the Apache 2.0 license. See the [LICENSE] [Apache 2.0] file for the full license.
 
-  [OWASP Dependency-Check]: https://www.owasp.org/index.php/OWASP_Dependency_Check
-  [Apache 2.0]: https://github.com/stevespringett/nist-data-mirror/blob/master/LICENSE
-  [pre-compiled binaries]: https://github.com/stevespringett/nist-data-mirror/releases
+[owasp dependency-check](https://www.owasp.org/index.php/OWASP_Dependency_Check)
+[apache 2.0](https://github.com/stevespringett/nist-data-mirror/blob/master/LICENSE)
+[pre-compiled binaries](https://github.com/stevespringett/nist-data-mirror/releases)

--- a/k8s/nist-data-mirror/README.md
+++ b/k8s/nist-data-mirror/README.md
@@ -1,22 +1,20 @@
-NIST Data Mirror Helm Chart
-===========================
+# NIST Data Mirror Helm Chart
 
 A simple helm chart to deploy NIST mirror in k8s.
 
 The intended purpose of this helm chart is to be able to deploy NIST mirror in k8s. Anyone who is using k8s to deploy services and tools, can use this and get started.
 
-Pre-requsite
--------------
+## Pre-requsite
+
 This chart will not create docker image, but rather deploy it in k8s. Please create image first and push it to your docker repo. You can use [docker-build.sh] script to create docker image.
 
-Usage
-----------------
+## Usage
 
 ### Packaging
 
 ```sh
 # cd to charts directory
-$ cd nist-data-mirror 
+$ cd nist-data-mirror
 
 # Create directory for package
 $ mkdir ./target
@@ -24,12 +22,13 @@ $ mkdir ./target
 # Package helm chart
 $ helm package --app-version <app_version>  --version <helm_chart_version> -destination ./target .
 
-# As a best practice, push your packaged chart to helm repo. e.g. push it to artifactory, chartmusuem etc. 
+# As a best practice, push your packaged chart to helm repo. e.g. push it to artifactory, chartmusuem etc.
 $ helm push target/nist-data-mirror-<helm_chart_version>.tgz chartmuseum
 ```
 
 ### Deploying
-You can have your k8s cluster anywhere (EKS, EKG, private cluster, etc), But you need to be able connect to k8s cluster to run this. For more details please check how to use [helm for deployments]. 
+
+You can have your k8s cluster anywhere (EKS, EKG, private cluster, etc), But you need to be able connect to k8s cluster to run this. For more details please check how to use [helm for deployments].
 
 ```sh
 # helm install --name <release_name> <helm_repo>/<chart_name>
@@ -40,11 +39,9 @@ The httpd server will take a minute to spin up as it is mirroring the initial NV
 
 ### Using as proxy
 
-Once deployment is complete, you should have nist-mirror running as service in k8s. If you created a service as type "loadBalancer", you can try and check loadBalancer endpoint to test it. Please check on details about how to use [LoadBalancers in K8S] 
+Once deployment is complete, you should have nist-mirror running as service in k8s. If you created a service as type "loadBalancer", you can try and check loadBalancer endpoint to test it. Please check on details about how to use [LoadBalancers in K8S]
 
-
-Copyright & License
--------------------
+### Copyright & License
 
 nist-data-mirror is Copyright (c) Steve Springett. All Rights Reserved.
 
@@ -52,8 +49,8 @@ Dependency-Check is Copyright (c) Jeremy Long. All Rights Reserved.
 
 Permission to modify and redistribute is granted under the terms of the Apache 2.0 license. See the [LICENSE] [Apache 2.0] file for the full license.
 
-  [OWASP Dependency-Check]: https://www.owasp.org/index.php/OWASP_Dependency_Check
-  [Apache 2.0]: https://github.com/stevespringett/nist-data-mirror/blob/master/LICENSE
-  [docker-build.sh]: https://github.com/stevespringett/nist-data-mirror/blob/master/docker-build.sh
-  [LoadBalancers in K8S]: https://kubernetes.io/docs/concepts/services-networking/
-  [helm for deployments]: https://helm.sh/docs/using_helm/
+[OWASP Dependency-Check](https://www.owasp.org/index.php/OWASP_Dependency_Check)
+[Apache 2.0](https://github.com/stevespringett/nist-data-mirror/blob/master/LICENSE)
+[docker-build.sh](https://github.com/stevespringett/nist-data-mirror/blob/master/docker-build.sh)
+[LoadBalancers in K8S](https://kubernetes.io/docs/concepts/services-networking/)
+[helm for deployments](https://helm.sh/docs/using_helm/)

--- a/k8s/nist-data-mirror/templates/nist-data-mirror-deployment.yaml
+++ b/k8s/nist-data-mirror/templates/nist-data-mirror-deployment.yaml
@@ -49,6 +49,10 @@ spec:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+          {{- with .Values.env }}
+{{- toYaml . | nindent 8 }}
+          {{- end }}    
         ports:
         - name: http
           containerPort: 80

--- a/k8s/nist-data-mirror/values.yaml
+++ b/k8s/nist-data-mirror/values.yaml
@@ -10,6 +10,12 @@ image:
 
 replicaCount: 1
 
+env:
+  - name: _JAVA_OPTIONS
+    value:
+      -Dhttps.proxyHost=yourproxyhost.domain -Dhttps.proxyPort=3128 -Dhttp.proxyHost=yourproxyhost.domain
+      -Dhttp.proxyPort=3128 -Dhttp.nonProxyHosts="localhost|*.domain"
+
 service:
   # Type of service you want to create. e.g. Loadbalancer, Nodeport, etc.
   type: ClusterIP

--- a/src/docker/scripts/mirror.sh
+++ b/src/docker/scripts/mirror.sh
@@ -2,7 +2,7 @@
 
 echo "Updating..."
 
-files=$(java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -jar -Dhttp.proxyHost="${proxy_host}" -Dhttp.proxyPort="${proxy_port}" /usr/local/bin/nist-data-mirror.jar /tmp/nvd | grep -Eo '(Download succeeded|Uncompressed).*' | grep -Eo '[^ ]*\.(gz|meta|json|xml)')
+files=$(java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -jar /usr/local/bin/nist-data-mirror.jar /tmp/nvd | grep -Eo '(Download succeeded|Uncompressed).*' | grep -Eo '[^ ]*\.(gz|meta|json|xml)')
 
 timestamp=$(date +%s)
 


### PR DESCRIPTION
It is better to leave the JVM options to be configurable so that the end user can configure more options not just proxy.
Also providing env configurable in values.yaml opens up opportunities for the users.
Updated the documentation to reflect the changes
Tested the image and helm chart in Kubernetes.

Note: Readme markdowns are formatted by the IDE. I touched up to not to have so many.