### PR TITLE
Write the output of mirror script to container stdout

### DIFF
--- a/src/docker/crontab/mirror
+++ b/src/docker/crontab/mirror
@@ -1,1 +1,1 @@
-0 */4 * * * /mirror.sh
+0 */4 * * * /mirror.sh >> /proc/1/fd/1 2>&1


### PR DESCRIPTION
I would like to see the output of the mirror script when it's run by cron for confirmation that it's working successfully, and that output is currently not available anywhere.  This will send it to supervisord's stdout (which is the container's stdout) so that I can see the output in the kubernetes container log.