### PR TITLE
Refactored error message when the output dir is not specified

### DIFF
--- a/src/main/java/us/springett/nistdatamirror/NistDataMirror.java
+++ b/src/main/java/us/springett/nistdatamirror/NistDataMirror.java
@@ -76,7 +76,7 @@ public class NistDataMirror {
     public static void main(String[] args) {
         // Ensure at least one argument was specified
         if (args.length != 1) {
-            System.out.println("Usage: java NistDataMirror outputDir");
+            System.out.println("Usage Error: Please only provide the output directory as parameter in the form: 'java nist-data-mirror.jar outputDir'");
             System.exit(EXIT_CODE_WRONG_INVOCATION);
             return;
         }


### PR DESCRIPTION
Recently updated to version 1.5.0 and the download did not happen anymore.
I am using the repo in a pipeline which has other steps after the `java -jar nist-data-mirror.jar outputDir json` and it was silently failing with the message **Usage: java NistDataMirror outputDir"** which does not look like an actual error message.
In the meanwhile I solved the problem by removing the **json** parameter as I also looked here into the source code and saw what the message actually meant 