### PR TITLE
Fixup setup java PR of dependabot

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2.3.4
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2.5.0
       with:
         java-version: 1.8
     - name: Build with Maven

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,6 +12,7 @@ jobs:
     - name: Set up JDK 1.8
       uses: actions/setup-java@v2.5.0
       with:
+        distribution: zulu
         java-version: 1.8
     - name: Build with Maven
       run: mvn clean package

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,6 +13,6 @@ jobs:
       uses: actions/setup-java@v2.5.0
       with:
         distribution: zulu
-        java-version: 1.8
+        java-version: 8
     - name: Build with Maven
       run: mvn clean package


### PR DESCRIPTION
Dependabot requested to update setup-java, but did not include the distribution that is required since v2.x
This PR builds on dependabots PR and upgrades to setup-java 2.5.0 using the same distribution (Azul Zulu) as v1 of the action.