### PR TITLE
Downloading and uncompressing from scratch is slower than needed

### DIFF
--- a/src/main/java/us/springett/nistdatamirror/MetaProperties.java
+++ b/src/main/java/us/springett/nistdatamirror/MetaProperties.java
@@ -17,11 +17,8 @@ package us.springett.nistdatamirror;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.IOException;
-import java.io.Reader;
-import java.io.StringReader;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -35,52 +32,9 @@ import java.util.Properties;
 public class MetaProperties {
 
     /**
-     * The SHA256 of the NVD file.
-     */
-    private String sha256;
-    /**
      * The last modified date of the NVD file in epoch time.
      */
-    private long lastModifiedDate;
-    /**
-     * The size of the NVD file.
-     */
-    private long size = 0;
-    /**
-     * The size of the zipped NVD file.
-     */
-    private long zipSize = 0;
-    /**
-     * The size of the gzipped NVD file.
-     */
-    private long gzSize = 0;
-
-    /**
-     * Get the value of gzSize.
-     *
-     * @return the value of gzSize
-     */
-    public long getGzSize() {
-        return gzSize;
-    }
-
-    /**
-     * Get the value of zipSize.
-     *
-     * @return the value of zipSize
-     */
-    public long getZipSize() {
-        return zipSize;
-    }
-
-    /**
-     * Get the value of size.
-     *
-     * @return the value of size
-     */
-    public long getSize() {
-        return size;
-    }
+    private final long lastModifiedDate;
 
     /**
      * Get the value of lastModifiedDate in epoch time.
@@ -89,15 +43,6 @@ public class MetaProperties {
      */
     public long getLastModifiedDate() {
         return lastModifiedDate;
-    }
-
-    /**
-     * Get the value of SHA256
-     *
-     * @return the value of SHA256
-     */
-    public String getSha256() {
-        return sha256;
     }
 
     /**
@@ -115,7 +60,6 @@ public class MetaProperties {
         } catch (IOException ex) {
             throw new MirrorException("Unable to parse meta file data", ex);
         }
-        this.sha256 = properties.getProperty("sha256");
         try {
             String date = properties.getProperty("lastModifiedDate");
             if (date == null) {
@@ -127,19 +71,19 @@ public class MetaProperties {
                     + properties.getProperty("lastModifiedDate"), ex);
         }
         try {
-            this.zipSize = Long.parseLong(properties.getProperty("zipSize"));
+            Long.parseLong(properties.getProperty("zipSize"));
         } catch (NumberFormatException ex) {
             throw new MirrorException("Meta file zip size cannot be parsed: "
                     + properties.getProperty("zipSize"), ex);
         }
         try {
-            this.gzSize = Long.parseLong(properties.getProperty("gzSize"));
+            Long.parseLong(properties.getProperty("gzSize"));
         } catch (NumberFormatException ex) {
             throw new MirrorException("Meta file gz size cannot be parsed: "
                     + properties.getProperty("gzSize"), ex);
         }
         try {
-            this.size = Long.parseLong(properties.getProperty("size"));
+            Long.parseLong(properties.getProperty("size"));
         } catch (NumberFormatException ex) {
             throw new MirrorException("Meta file size cannot be parsed: "
                     + properties.getProperty("size"), ex);

--- a/src/main/java/us/springett/nistdatamirror/MirrorException.java
+++ b/src/main/java/us/springett/nistdatamirror/MirrorException.java
@@ -31,31 +31,6 @@ public class MirrorException extends IOException {
 
     /**
      * Creates a new MirrorException.
-     */
-    public MirrorException() {
-        super();
-    }
-
-    /**
-     * Creates a new MirrorException.
-     *
-     * @param msg a message for the exception.
-     */
-    public MirrorException(String msg) {
-        super(msg);
-    }
-
-    /**
-     * Creates a new MirrorException.
-     *
-     * @param ex the cause of the exception.
-     */
-    public MirrorException(Throwable ex) {
-        super(ex);
-    }
-
-    /**
-     * Creates a new MirrorException.
      *
      * @param msg a message for the exception.
      * @param ex the cause of the exception.

--- a/src/main/java/us/springett/nistdatamirror/NistDataMirror.java
+++ b/src/main/java/us/springett/nistdatamirror/NistDataMirror.java
@@ -250,12 +250,12 @@ public class NistDataMirror {
 
     private void uncompress(File file) {
         byte[] buffer = new byte[1024];
-        GZIPInputStream gzis = null;
-        FileOutputStream out = null;
+        InputStream gzis = null;
+        OutputStream out = null;
         try {
             File outputFile = new File(file.getAbsolutePath().replaceAll(".gz", ""));
-            gzis = new GZIPInputStream(new FileInputStream(file));
-            out = new FileOutputStream(outputFile);
+            gzis = new GZIPInputStream(new BufferedInputStream(new FileInputStream(file)));
+            out = new BufferedOutputStream(new FileOutputStream(outputFile));
             int len;
             while ((len = gzis.read(buffer)) > 0) {
                 out.write(buffer, 0, len);
@@ -305,7 +305,7 @@ public class NistDataMirror {
     private static String checksum(String filepath, MessageDigest md) throws IOException {
 
         // file hashing with DigestInputStream
-        try (DigestInputStream dis = new DigestInputStream(new FileInputStream(filepath), md)) {
+        try (DigestInputStream dis = new DigestInputStream(new BufferedInputStream(new FileInputStream(filepath)), md)) {
             while (dis.read() != -1) ; //empty loop to clear the data
             md = dis.getMessageDigest();
         }

--- a/src/main/java/us/springett/nistdatamirror/NistDataMirror.java
+++ b/src/main/java/us/springett/nistdatamirror/NistDataMirror.java
@@ -16,8 +16,6 @@
 package us.springett.nistdatamirror;
 
 
-import com.sun.org.apache.xpath.internal.operations.Bool;
-
 import java.io.*;
 import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
@@ -67,14 +65,14 @@ public class NistDataMirror {
     private final Proxy proxy;
 
     {
-    	Map<String, String> version11Filenames = new HashMap<>();
-    	version11Filenames.put("cveJsonModifiedUrl", CVE_JSON_11_MODIFIED_URL);
+        Map<String, String> version11Filenames = new HashMap<>();
+        version11Filenames.put("cveJsonModifiedUrl", CVE_JSON_11_MODIFIED_URL);
         version11Filenames.put("cveJsonRecentUrl", CVE_JSON_11_RECENT_URL);
-    	version11Filenames.put("cveJsonBaseUrl", CVE_JSON_11_BASE_URL);
-    	version11Filenames.put("cveModifiedMeta", CVE_MODIFIED_11_META);
+        version11Filenames.put("cveJsonBaseUrl", CVE_JSON_11_BASE_URL);
+        version11Filenames.put("cveModifiedMeta", CVE_MODIFIED_11_META);
         version11Filenames.put("cveRecentMeta", CVE_RECENT_11_META);
-    	version11Filenames.put("cveBaseMeta", CVE_BASE_11_META);
-    	versionToFilenameMaps.put("1.1", version11Filenames);
+        version11Filenames.put("cveBaseMeta", CVE_BASE_11_META);
+        versionToFilenameMaps.put("1.1", version11Filenames);
     }
 
     public static void main(String[] args) {
@@ -111,10 +109,11 @@ public class NistDataMirror {
                 System.out.println("Using proxy user " + proxyUser + ":" + proxyPassword);
                 Authenticator authenticator = new Authenticator() {
 
-                   public PasswordAuthentication getPasswordAuthentication() {
-                       return (new PasswordAuthentication(proxyUser,
-                             proxyPassword.toCharArray()));
-                   }
+                    @Override
+                    public PasswordAuthentication getPasswordAuthentication() {
+                        return (new PasswordAuthentication(proxyUser,
+                                proxyPassword.toCharArray()));
+                    }
 
                 };
                 Authenticator.setDefault(authenticator);
@@ -152,13 +151,13 @@ public class NistDataMirror {
                 downloadVersionForYear(version, year);
                 Boolean valid = validCheck(year);
                 System.out.println("File " + year + " is valid.");
-                if (Boolean.FALSE.equals(valid)){
+                if (Boolean.FALSE.equals(valid)) {
                     int i = 0;
-                    while (i < 2){
+                    while (i < 2) {
                         downloadVersionForYear(version, year);
                         Boolean valid2 = validCheck(year);
                         i++;
-                        if (Boolean.TRUE.equals(valid2)){
+                        if (Boolean.TRUE.equals(valid2)) {
                             System.out.println("File " + year + " is valid.");
                             break;
                         }
@@ -176,18 +175,18 @@ public class NistDataMirror {
         }
     }
 
-	private void downloadVersionForYear(String version, int year) throws MirrorException {
-		MetaProperties before;
-		MetaProperties after;
-		String cveBaseMetaUrl = versionToFilenameMaps.get(version).get("cveBaseMeta").replace("%d", String.valueOf(year));
-		before = readLocalMetaForURL(cveBaseMetaUrl);
-		doDownload(cveBaseMetaUrl);
-		after = readLocalMetaForURL(cveBaseMetaUrl);
-		if (before == null || after.getLastModifiedDate() > before.getLastModifiedDate()) {
-		    String cveJsonBaseUrl = versionToFilenameMaps.get(version).get("cveJsonBaseUrl").replace("%d", String.valueOf(year));
-		    doDownload(cveJsonBaseUrl);
-		}
-	}
+    private void downloadVersionForYear(String version, int year) throws MirrorException {
+        MetaProperties before;
+        MetaProperties after;
+        String cveBaseMetaUrl = versionToFilenameMaps.get(version).get("cveBaseMeta").replace("%d", String.valueOf(year));
+        before = readLocalMetaForURL(cveBaseMetaUrl);
+        doDownload(cveBaseMetaUrl);
+        after = readLocalMetaForURL(cveBaseMetaUrl);
+        if (before == null || after.getLastModifiedDate() > before.getLastModifiedDate()) {
+            String cveJsonBaseUrl = versionToFilenameMaps.get(version).get("cveJsonBaseUrl").replace("%d", String.valueOf(year));
+            doDownload(cveJsonBaseUrl);
+        }
+    }
 
     private MetaProperties readLocalMetaForURL(String metaUrl) throws MirrorException {
         URL url;
@@ -227,10 +226,12 @@ public class NistDataMirror {
             bis = new BufferedInputStream(connection.getInputStream());
             file = new File(outputDir, filename);
             bos = new BufferedOutputStream(new FileOutputStream(file));
-
+           
             int i;
+            long count = 0;
             while ((i = bis.read()) != -1) {
                 bos.write(i);
+                count++;
             }
             success = true;
         } catch (IOException e) {
@@ -280,42 +281,55 @@ public class NistDataMirror {
     }
 
     /**
-     * This function checks, if the generated Hash of the json file matches the hashcode in the meta file
+     * This function checks, if the generated Hash of the json file matches the
+     * hashcode in the meta file
+     *
      * @param year
      * @return true or false
      */
     private Boolean validCheck(int year) {
-                try {
-                    Path metaFilePath = Paths.get(String.valueOf(outputDir), "nvdcve-1.1-" + year + ".meta");
-                    int n = 4; // The line number where the hash is saved in the meta file
-                    String hashLine = Files.readAllLines(Paths.get(String.valueOf(metaFilePath))).get(n);
-                    String metaHash = hashLine.substring(7);
+        try {
+            Path metaFilePath = Paths.get(String.valueOf(outputDir), "nvdcve-1.1-" + year + ".meta");
+            int n = 4; // The line number where the hash is saved in the meta file
+            String hashLine = Files.readAllLines(Paths.get(String.valueOf(metaFilePath))).get(n);
+            String metaHash = hashLine.substring(7);
 
-                    MessageDigest md = MessageDigest.getInstance("SHA-256");
-                    Path jsonFilePath = Paths.get(String.valueOf(outputDir), "nvdcve-1.1-" + year + ".json");
-                    String hex = checksum(String.valueOf(jsonFilePath), md);
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            Path jsonFilePath = Paths.get(String.valueOf(outputDir), "nvdcve-1.1-" + year + ".json");
+            String hex = checksum(String.valueOf(jsonFilePath), md);
 
-                    return metaHash.equals(hex);
-                } catch (IOException | NoSuchAlgorithmException ex) {
-                    ex.printStackTrace();
-                }
+            return metaHash.equals(hex);
+        } catch (IOException | NoSuchAlgorithmException ex) {
+            ex.printStackTrace();
+        }
         return null;
     }
 
     private static String checksum(String filepath, MessageDigest md) throws IOException {
 
         // file hashing with DigestInputStream
-        try (DigestInputStream dis = new DigestInputStream(new BufferedInputStream(new FileInputStream(filepath)), md)) {
+        try ( DigestInputStream dis = new DigestInputStream(new BufferedInputStream(new FileInputStream(filepath)), md)) {
             while (dis.read() != -1) ; //empty loop to clear the data
             md = dis.getMessageDigest();
         }
 
         // bytes to hex
-        StringBuilder result = new StringBuilder();
-        for (byte b : md.digest()) {
-            result.append(String.format("%02x", b));
-        }
-        return result.toString().toUpperCase(Locale.ROOT);
+        final byte[] digest = md.digest();
+        String digestHexString = bytesToHex(digest);
+        return digestHexString.toUpperCase(Locale.ROOT);
 
     }
+
+    // https://stackoverflow.com/a/9855338/53897
+    private static final char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
+
+    public static String bytesToHex(byte[] bytes) {
+        char[] hexChars = new char[bytes.length * 2];
+        for (int j = 0; j < bytes.length; j++) {
+            int v = bytes[j] & 0xFF;
+            hexChars[j * 2] = HEX_ARRAY[v >>> 4];
+            hexChars[j * 2 + 1] = HEX_ARRAY[v & 0x0F];
+        }
+        return new String(hexChars);
     }
+}


### PR DESCRIPTION
Looked at this as part of investigating how to create an offline in-house procedure.  Found this to be very slow, and discovered that the downloading and uncompressing is not buffered, and the byte[]->Hex string is repeatedly invoking String.format.

Fixing this caused the run time on my machine went from 53 minutes down to 44 seconds.