### PR TITLE
Set correct VCS label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE
 LABEL org.label-schema.name="sspringett/nvdmirror"
 LABEL org.label-schema.description="NIST Data Mirror"
 LABEL org.label-schema.url="https://github.com/stevespringett/nist-data-mirror"
-LABEL org.label-schema.vcs-url="https://github.com/ballerinalang/container-support"
+LABEL org.label-schema.vcs-url="https://github.com/stevespringett/nist-data-mirror"
 LABEL org.label-schema.vendor="sspringett"
 LABEL org.label-schema.version=$BUILD_VERSION
 LABEL org.label-schema.docker.cmd="docker run -dit --name mirror -p 80:80 --mount type=bind,source=\"$(pwd)\"/target/docs/,target=/usr/local/apache2/htdocs sspringett/nvdmirror"


### PR DESCRIPTION
Current label value for 'org.label-schema.vcs-url' is pointing to some archived project, unrelated to nist-data-mirror.
This label is used by automation tools which generate links to the wrong project.